### PR TITLE
build: Ajout de commandes pour la maintenance et les permissions

### DIFF
--- a/update-production.sh
+++ b/update-production.sh
@@ -6,7 +6,7 @@ git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 composer install --prefer-dist --no-interaction
 npm install
 
-php artisan migrate:fresh --seed --force
+php artisan migrate --force
 php artisan optimize
 php artisan view:clear
 php artisan horizon:terminate

--- a/update-production.sh
+++ b/update-production.sh
@@ -1,4 +1,5 @@
 #\bin\bash
+php artisan down
 
 git reset --hard
 git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
@@ -10,3 +11,6 @@ php artisan migrate --force
 php artisan optimize
 php artisan view:clear
 php artisan horizon:terminate
+chmod -R 777 storage bootstrap/cache
+
+php artisan up

--- a/update-staging.sh
+++ b/update-staging.sh
@@ -1,5 +1,7 @@
 #\bin\bash
 
+php artisan down
+
 git reset --hard
 git pull origin master
 
@@ -10,3 +12,5 @@ php artisan migrate:fresh --seed
 php artisan optimize
 php artisan view:clear
 php artisan horizon:terminate
+
+php artisan up

--- a/update-staging.sh
+++ b/update-staging.sh
@@ -12,5 +12,6 @@ php artisan migrate:fresh --seed
 php artisan optimize
 php artisan view:clear
 php artisan horizon:terminate
+chmod -R 777 storage bootstrap/cache
 
 php artisan up


### PR DESCRIPTION
…roduction

- Remplacement de "migrate:fresh --seed" par "migrate" dans update-production.sh
- Ajout de "php artisan down" et "php artisan up" dans update-staging.sh pour activer et désactiver le mode maintenance lors des mises à jour
- Ajout des commandes 'php artisan down' et 'php artisan up' pour le mode maintenance
- Ajout de la commande 'chmod -R 777 storage bootstrap/cache' pour les permissions de stockage et de mise en cache